### PR TITLE
chore: adopt leading public repo best practices (AGENTS.md, gitattributes, Dependabot, CodeQL, PR template, release notes)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto eol=lf
+*.py    text diff=python
+*.md    text
+*.yml   text
+*.yaml  text
+*.json  text
+*.sh    text eol=lf
+*.png   binary
+*.jpg   binary
+*.pdf   binary
+# Generated / vendored
+docs/_build/** linguist-generated=true
+examples/audit_chain/**.jsonl linguist-generated=true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,3 +45,10 @@
 ## Regulatory Context
 
 <!-- Optional: which regulation or audit finding motivated this change? -->
+
+
+## Agent attribution (if AI-authored)
+- Agent: <!-- claude-code / copilot / gemini / codex / human -->
+- Session transcript / link:
+- Human reviewer who validated the changes:
+- [ ] Followed `AGENTS.md` hard rules

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "23 4 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This repo encodes governance patterns for autonomous AI agents in regulated fina
 - One logical change per PR. No drive-by reformatting.
 - Include the agent session transcript (or a link to it) in the PR body.
 - Run `pre-commit run --all-files` and `pytest -q` before pushing.
-- Map the change to EU AI Act articles when relevant (see `docs/eu_ai_act.md`).
+- Map the change to EU AI Act articles when relevant (see `docs/eu_ai_act_mapping.md`).
 
 ## Tone
 - Commit messages: Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent Contributor Guidelines
+
+This repo encodes governance patterns for autonomous AI agents in regulated financial services. If you are an AI coding agent (Claude, Copilot, Gemini, Codex, etc.) opening a PR here, follow these rules to avoid "agentic slop."
+
+## Hard rules
+1. Never weaken DEFCON state transitions or Sovereign Veto semantics without an ADR in `docs/adr/` explaining the regulatory impact.
+2. Every change touching `patterns/`, `schemas/`, or `examples/` MUST include a corresponding test in `tests/` and a CHANGELOG entry.
+3. Audit Chain entries are append-only. Never rewrite history in `examples/audit_chain/`.
+4. Human-in-the-loop checkpoints are non-negotiable. Do not refactor them into auto-approve paths.
+
+## PR hygiene
+- One logical change per PR. No drive-by reformatting.
+- Include the agent session transcript (or a link to it) in the PR body.
+- Run `pre-commit run --all-files` and `pytest -q` before pushing.
+- Map the change to EU AI Act articles when relevant (see `docs/eu_ai_act.md`).
+
+## Tone
+- Commit messages: Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`).
+- No marketing language in code comments.
+- Cite sources for any regulatory claim.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,23 @@
+# Release Notes
+
+## v0.1.0 — Initial public release (2026-05-15)
+
+### Highlights
+- Governance patterns for autonomous AI agents in regulated financial services
+- DEFCON state machine reference implementation
+- Sovereign Veto pattern + examples
+- Append-only Audit Chain schema (JSONL)
+- EU AI Act article mapping
+- Human-in-the-loop checkpoint patterns
+- Paper-trading Phase 0 examples; no live capital
+
+### Repo hygiene
+- AGENTS.md contributor guidelines for AI coding agents
+- .gitattributes for line-ending and diff hygiene
+- Dependabot (pip + github-actions)
+- CodeQL security scanning
+- Copilot automatic code review on default branch
+
+### Notes
+- This is a 0.x release. Schemas and pattern names may change before 1.0.
+- See CHANGELOG.md for the granular change log.


### PR DESCRIPTION
## Summary
Adopts practices observed in leading public repos (e.g., obra/superpowers) and applies them here.

## Changes
- Add `AGENTS.md` contributor guidelines for AI coding agents (Claude, Copilot, Gemini, Codex)
- Add `.gitattributes` for line-ending and diff hygiene
- Add `.github/dependabot.yml` for weekly pip + github-actions updates
- Add `.github/workflows/codeql.yml` for Python static security analysis
- Append agent-attribution section to PR template
- Add `RELEASE-NOTES.md` seeded with v0.1.0

## Follow-ups (post-merge)
- Create the v0.1.0 release/tag
- Add branch protection ruleset on `main` (require CI + Copilot review, block force-push)
- Investigate failing `production` Pages deployment

## Agent attribution
- Agent: comet (Perplexity browser agent)
- Human reviewer who validated: @linus10x
