### PR TITLE
chore(deps): add Dependabot config for pip and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "pip"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "actions"
+      include: "scope"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Added configuration for pip and GitHub Actions updates with specific schedules and limits.

## What does this PR do?

<!-- One sentence summary -->

## Type of change

| Type | This PR? |
|---|---|
| New governance pattern | ☐ |
| Bug fix (existing pattern) | ☐ |
| Documentation update | ☐ |
| CI / tooling | ☐ |
| Refactor (no behaviour change) | ☐ |

## Checklist

- [ ] `ruff check .` passes locally with zero violations
- [ ] `ruff format --check .` passes
- [ ] `mypy` passes with zero errors
- [ ] `pytest --cov` passes and coverage stays ≥ 80%
- [ ] New pattern includes: docstring, type hints, at least one test, and regulation mapping
- [ ] CHANGELOG.md updated under `[Unreleased]`
- [ ] If a new pattern: `README.md` patterns table updated

## Regulation mapping (for new patterns)

<!-- Which regulation or standard does this pattern address? -->
<!-- e.g. EU AI Act Art. 12, SEC Rule 17a-4, MiFID II Art. 17 -->

## Testing notes

<!-- How was this tested? Any edge cases exercised? -->

## Related issues

Closes #
